### PR TITLE
Enable --random-feeds flag

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -446,7 +446,7 @@ async def report(
             "transaction_type": tx_type,
             "min_native_token_balance": int(min_native_token_balance * 10**18),
             "check_rewards": check_rewards,
-            #"use_random_feeds": use_random_feeds, #TODO: Error if this line is uncommented
+            "use_random_feeds": use_random_feeds,
             "gas_multiplier": gas_multiplier,
         }
 

--- a/src/telliot_feeds/reporters/fetch_flex.py
+++ b/src/telliot_feeds/reporters/fetch_flex.py
@@ -26,6 +26,7 @@ from telliot_feeds.utils.log import get_logger
 from telliot_feeds.utils.reporter_utils import get_native_token_feed
 from telliot_feeds.utils.reporter_utils import fetch_suggested_report
 from telliot_feeds.utils.reporter_utils import tkn_symbol
+from telliot_feeds.utils.reporter_utils import suggest_working_random_feed
 
 
 logger = get_logger(__name__)
@@ -54,6 +55,7 @@ class FetchFlexReporter(IntervalReporter):
         wait_period: int = 7,
         min_native_token_balance: int = 10**18,
         check_rewards: bool = True,
+        use_random_feeds: bool = False
     ) -> None:
 
         self.endpoint = endpoint
@@ -78,6 +80,7 @@ class FetchFlexReporter(IntervalReporter):
         self.qtag_selected = False if self.datafeed is None else True
         self.min_native_token_balance = min_native_token_balance
         self.check_rewards: bool = check_rewards
+        self.use_random_feeds: bool = use_random_feeds
         self.web3 = self.endpoint.web3
 
         self.gas_info: dict[str, Union[float, int]] = {}
@@ -232,6 +235,9 @@ class FetchFlexReporter(IntervalReporter):
     async def fetch_datafeed(self) -> Optional[DataFeed[Any]]:
         """Fetches datafeed suggestion plus the reward amount from autopay if query tag isn't selected
         if query tag is selected fetches the rewards, if any, for that query tag"""
+        if self.use_random_feeds:
+            self.datafeed = suggest_working_random_feed()
+
         if self.datafeed:
             # add query id to catalog to fetch tip for legacy autopay
             try:

--- a/src/telliot_feeds/utils/reporter_utils.py
+++ b/src/telliot_feeds/utils/reporter_utils.py
@@ -61,7 +61,16 @@ async def fetch_suggested_report(
 
     else:
         return None
+    
+def suggest_working_random_feed() -> DataFeed[Any]:
+    """Suggest a random tried and tested feed to report against."""
 
+    available_feeds_tags = [
+        "pls-usd-spot",
+        "fetch-usd-spot"
+    ]
+
+    return random.choice([CATALOG_FEEDS[feed] for feed in available_feeds_tags])
 
 def suggest_random_feed() -> DataFeed[Any]:
     """Suggest a random feed to report against."""


### PR DESCRIPTION
Enable, for now, the usage of -rf flag only for tokens from PLS chain. 