### PR TITLE
Fix FetchRNG reporting

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -369,7 +369,7 @@ async def report(
                 return
             chosen_feed = None
         elif rng_timestamp is not None:
-            chosen_feed = await assemble_rng_datafeed(timestamp=rng_timestamp, node=core.endpoint, account=account)
+            chosen_feed = await assemble_rng_datafeed(timestamp=rng_timestamp)
         else:
             chosen_feed = None
 

--- a/src/telliot_feeds/feeds/fetch_rng_feed.py
+++ b/src/telliot_feeds/feeds/fetch_rng_feed.py
@@ -9,12 +9,12 @@ from telliot_feeds.queries.fetch_rng import FetchRNG
 from telliot_feeds.sources.blockhash_aggregator import FetchRNGManualSource
 
 local_source = FetchRNGManualSource()
-
+local_source.set_timestamp(1660567612)
 fetch_rng_feed = DataFeed(source=local_source, query=FetchRNG(timestamp=local_source.timestamp))
 
 
 async def assemble_rng_datafeed(
-    timestamp: int, node: RPCEndpoint, account: chained_accounts
+    timestamp: int
 ) -> Optional[DataFeed[float]]:
     """Assembles a FetchRNG datafeed for the given timestamp."""
     local_source.set_timestamp(timestamp)


### PR DESCRIPTION
To use the FetchRNG example timestamp (1660567612):
`telliot report -a myacc1 -qtfetch-rng-example -ncr --fetch-flex`

To pass a timestamp for telliot:
`telliot report -a myacc1--rng-timestamp<timestamp> -ncr --fetch-flex`

Please note that:

1. This is following the TellorRNG specification.
2. Many timestamps will return the same number since the BTC block interval is lengthy. You can check at https://blockchain.info/blocks/1690567999000?format=json how timestamps are significantly apart each other.
3. You may not choose a query tag while using rng-timestamp option