### PR TITLE
KeyError fix when no data received from pulsexv2

### DIFF
--- a/src/telliot_feeds/feeds/pls_usd_feed.py
+++ b/src/telliot_feeds/feeds/pls_usd_feed.py
@@ -15,12 +15,8 @@ pls_usd_median_feed = DataFeed(
             PulseXRPC(asset="wpls", currency="dai"),
             PulseXRPC(asset="wpls", currency="usdc"),
             PulseXRPC(asset="wpls", currency="usdt"),
-            DexScreenerApiSource(asset="369,pulsex,wpls", currency="dai"),
             DexScreenerApiSource(asset="369,pulsexv2,wpls", currency="dai"),
-            DexScreenerApiSource(asset="369,pulsex,wpls", currency="usdc"),
-            DexScreenerApiSource(asset="369,pulsex,wpls", currency="usdt"),
             DexScreenerApiSource(asset="369,pulsexv2,wpls", currency="plsx"),
-            DexScreenerApiSource(asset="369,9inch,wpls", currency="plsx"),
         ],
     ),
 )

--- a/src/telliot_feeds/sources/price/spot/pulsex_subgraph_v2.py
+++ b/src/telliot_feeds/sources/price/spot/pulsex_subgraph_v2.py
@@ -104,20 +104,30 @@ class PulseXSubgraphv2Service(WebPriceService):
         elif "response" in data:
             response = data["response"]
 
+            logger.debug(f"PulseX Subgraph Response: {response}")
+            if "errors" in response:
+                logger.error(f"PulseX Subgraph Error: {response['errors']}")
+                return None, None
+
             try:
-                if response["data"]["token"] == None:
+
+                token_data = response.get("data", {}).get("token")
+
+                if token_data is None:
                     logger.error(f"No data found for the token {token}")
                     logger.error(f"It is possible that no Liquidity Pool exists including this token ({token})")
                     return None, None
 
-                price = float(response["data"]["token"]["derivedUSD"])
-                logger.info(f"Price for {asset}/{currency}: {price}")
+                price = float(token_data["derivedUSD"])
+                logger.info(f"price of {asset}/{currency}: {price}")
                 return price, datetime_now_utc()
             except KeyError as e:
                 msg = f"Error parsing Pulsechain Subgraph response: KeyError: {e}"
-                if response["data"]["token"] == None:
-                    msg = f"Invalid token address: {token}"
-                logger.critical(msg)
+                logger.error(msg)
+                return None, None
+            except ValueError as e:
+                msg = f"Error converting 'derivedUSD' to float: {e}"
+                logger.error(msg)
                 return None, None
 
         else:


### PR DESCRIPTION
Using .get to correctly handle KeyErrors.
Reduced sources in pls feed because they were redundant thus making the feed faster with less things to query and more robust